### PR TITLE
Make import of `SqlBackend` fields explicit

### DIFF
--- a/aws-xray-client-persistent/CHANGELOG.md
+++ b/aws-xray-client-persistent/CHANGELOG.md
@@ -1,6 +1,10 @@
-## [*Unreleased*](https://github.com/freckle/aws-xray-client/tree/aws-xray-client-persistent-v0.1.0.0...main)
+## [*Unreleased*](https://github.com/freckle/aws-xray-client/tree/aws-xray-client-persistent-v0.1.0.1...main)
 
 None
+
+## [v0.1.0.1](https://github.com/freckle/aws-xray-client/tree/aws-xray-client-persistent-v0.1.0.0...aws-xray-client-persistent-v0.1.0.1)
+
+- Add explicit import for `SqlBackend` fields
 
 ## [v0.1.0.0](https://github.com/freckle/aws-xray-client/tree/aws-xray-client-persistent-v0.1.0.0)
 

--- a/aws-xray-client-persistent/aws-xray-client-persistent.cabal
+++ b/aws-xray-client-persistent/aws-xray-client-persistent.cabal
@@ -1,13 +1,13 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.33.0.
+-- This file has been generated from package.yaml by hpack version 0.34.4.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 683943cc3d89e01c103f283b419b076d204a8c07ed66e3e1452d2dffc98f40ea
+-- hash: 132d0ad350f9df2b66a64bf3e14482e8847c3798baddbc58ddb3cea091b827e3
 
 name:           aws-xray-client-persistent
-version:        0.1.0.0
+version:        0.1.0.1
 synopsis:       A client for AWS X-Ray integration with Persistent.
 description:    Works with `aws-xray-client` to enable X-Ray tracing with Persistent.
 homepage:       https://github.com/freckle/aws-xray-client#readme
@@ -32,7 +32,31 @@ library
       Paths_aws_xray_client_persistent
   hs-source-dirs:
       library
-  default-extensions: BangPatterns DataKinds DeriveAnyClass DeriveFoldable DeriveFunctor DeriveGeneric DeriveLift DeriveTraversable DerivingStrategies FlexibleContexts FlexibleInstances GADTs GeneralizedNewtypeDeriving LambdaCase MultiParamTypeClasses NoImplicitPrelude NoMonomorphismRestriction OverloadedStrings RankNTypes RecordWildCards ScopedTypeVariables StandaloneDeriving TypeApplications TypeFamilies
+  default-extensions:
+      BangPatterns
+      DataKinds
+      DeriveAnyClass
+      DeriveFoldable
+      DeriveFunctor
+      DeriveGeneric
+      DeriveLift
+      DeriveTraversable
+      DerivingStrategies
+      FlexibleContexts
+      FlexibleInstances
+      GADTs
+      GeneralizedNewtypeDeriving
+      LambdaCase
+      MultiParamTypeClasses
+      NoImplicitPrelude
+      NoMonomorphismRestriction
+      OverloadedStrings
+      RankNTypes
+      RecordWildCards
+      ScopedTypeVariables
+      StandaloneDeriving
+      TypeApplications
+      TypeFamilies
   build-depends:
       aws-xray-client
     , base <5

--- a/aws-xray-client-persistent/library/Network/AWS/XRayClient/Persistent.hs
+++ b/aws-xray-client-persistent/library/Network/AWS/XRayClient/Persistent.hs
@@ -15,7 +15,8 @@ import Data.Text (Text)
 import Data.Time.Clock.POSIX
 import Database.Persist
 import Database.Persist.Sql
-import Database.Persist.Sql.Types.Internal (IsPersistBackend(mkPersistBackend), SqlBackend(..))
+import Database.Persist.Sql.Types.Internal
+  (IsPersistBackend(mkPersistBackend), SqlBackend(..))
 import Network.AWS.XRayClient.Segment
 import Network.AWS.XRayClient.TraceId
 import System.Random

--- a/aws-xray-client-persistent/library/Network/AWS/XRayClient/Persistent.hs
+++ b/aws-xray-client-persistent/library/Network/AWS/XRayClient/Persistent.hs
@@ -15,7 +15,7 @@ import Data.Text (Text)
 import Data.Time.Clock.POSIX
 import Database.Persist
 import Database.Persist.Sql
-import Database.Persist.Sql.Types.Internal (IsPersistBackend(mkPersistBackend))
+import Database.Persist.Sql.Types.Internal (IsPersistBackend(mkPersistBackend), SqlBackend(..))
 import Network.AWS.XRayClient.Segment
 import Network.AWS.XRayClient.TraceId
 import System.Random

--- a/aws-xray-client-persistent/package.yaml
+++ b/aws-xray-client-persistent/package.yaml
@@ -1,5 +1,5 @@
 name: aws-xray-client-persistent
-version: 0.1.0.0
+version: 0.1.0.1
 github:  "freckle/aws-xray-client"
 license: MIT
 author: "Freckle R&D"

--- a/aws-xray-client-wai/aws-xray-client-wai.cabal
+++ b/aws-xray-client-wai/aws-xray-client-wai.cabal
@@ -1,10 +1,10 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.33.0.
+-- This file has been generated from package.yaml by hpack version 0.34.4.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 7d2c5780fa214b7483f6d74bd71340b3877c684d3038276c485ba74ebd8081cb
+-- hash: f74520555888fb3dcf133e4aa61d7e18516c473f86ad33ad3c1668d477c8efb7
 
 name:           aws-xray-client-wai
 version:        0.1.0.0
@@ -32,7 +32,31 @@ library
       Paths_aws_xray_client_wai
   hs-source-dirs:
       library
-  default-extensions: BangPatterns DataKinds DeriveAnyClass DeriveFoldable DeriveFunctor DeriveGeneric DeriveLift DeriveTraversable DerivingStrategies FlexibleContexts FlexibleInstances GADTs GeneralizedNewtypeDeriving LambdaCase MultiParamTypeClasses NoImplicitPrelude NoMonomorphismRestriction OverloadedStrings RankNTypes RecordWildCards ScopedTypeVariables StandaloneDeriving TypeApplications TypeFamilies
+  default-extensions:
+      BangPatterns
+      DataKinds
+      DeriveAnyClass
+      DeriveFoldable
+      DeriveFunctor
+      DeriveGeneric
+      DeriveLift
+      DeriveTraversable
+      DerivingStrategies
+      FlexibleContexts
+      FlexibleInstances
+      GADTs
+      GeneralizedNewtypeDeriving
+      LambdaCase
+      MultiParamTypeClasses
+      NoImplicitPrelude
+      NoMonomorphismRestriction
+      OverloadedStrings
+      RankNTypes
+      RecordWildCards
+      ScopedTypeVariables
+      StandaloneDeriving
+      TypeApplications
+      TypeFamilies
   build-depends:
       aws-xray-client
     , base <5

--- a/aws-xray-client/aws-xray-client.cabal
+++ b/aws-xray-client/aws-xray-client.cabal
@@ -1,10 +1,10 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.33.0.
+-- This file has been generated from package.yaml by hpack version 0.34.4.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: e516a55724e36afdd43e4e056cf523538bbd27feb5c5ec3fb2279bf0b5e5a726
+-- hash: 75ce92092507bcaf0ef00000194035a6793a29e7ff13bb4fb0ffa0c77c851cec
 
 name:           aws-xray-client
 version:        0.1.0.0
@@ -40,7 +40,31 @@ library
       Paths_aws_xray_client
   hs-source-dirs:
       library
-  default-extensions: BangPatterns DataKinds DeriveAnyClass DeriveFoldable DeriveFunctor DeriveGeneric DeriveLift DeriveTraversable DerivingStrategies FlexibleContexts FlexibleInstances GADTs GeneralizedNewtypeDeriving LambdaCase MultiParamTypeClasses NoImplicitPrelude NoMonomorphismRestriction OverloadedStrings RankNTypes RecordWildCards ScopedTypeVariables StandaloneDeriving TypeApplications TypeFamilies
+  default-extensions:
+      BangPatterns
+      DataKinds
+      DeriveAnyClass
+      DeriveFoldable
+      DeriveFunctor
+      DeriveGeneric
+      DeriveLift
+      DeriveTraversable
+      DerivingStrategies
+      FlexibleContexts
+      FlexibleInstances
+      GADTs
+      GeneralizedNewtypeDeriving
+      LambdaCase
+      MultiParamTypeClasses
+      NoImplicitPrelude
+      NoMonomorphismRestriction
+      OverloadedStrings
+      RankNTypes
+      RecordWildCards
+      ScopedTypeVariables
+      StandaloneDeriving
+      TypeApplications
+      TypeFamilies
   build-depends:
       aeson
     , base <5
@@ -63,7 +87,31 @@ test-suite spec
       Paths_aws_xray_client
   hs-source-dirs:
       tests
-  default-extensions: BangPatterns DataKinds DeriveAnyClass DeriveFoldable DeriveFunctor DeriveGeneric DeriveLift DeriveTraversable DerivingStrategies FlexibleContexts FlexibleInstances GADTs GeneralizedNewtypeDeriving LambdaCase MultiParamTypeClasses NoImplicitPrelude NoMonomorphismRestriction OverloadedStrings RankNTypes RecordWildCards ScopedTypeVariables StandaloneDeriving TypeApplications TypeFamilies
+  default-extensions:
+      BangPatterns
+      DataKinds
+      DeriveAnyClass
+      DeriveFoldable
+      DeriveFunctor
+      DeriveGeneric
+      DeriveLift
+      DeriveTraversable
+      DerivingStrategies
+      FlexibleContexts
+      FlexibleInstances
+      GADTs
+      GeneralizedNewtypeDeriving
+      LambdaCase
+      MultiParamTypeClasses
+      NoImplicitPrelude
+      NoMonomorphismRestriction
+      OverloadedStrings
+      RankNTypes
+      RecordWildCards
+      ScopedTypeVariables
+      StandaloneDeriving
+      TypeApplications
+      TypeFamilies
   ghc-options: -threaded -rtsopts -O0 "-with-rtsopts=-N"
   build-depends:
       QuickCheck
@@ -85,7 +133,31 @@ benchmark bench
       Paths_aws_xray_client
   hs-source-dirs:
       benchmarks
-  default-extensions: BangPatterns DataKinds DeriveAnyClass DeriveFoldable DeriveFunctor DeriveGeneric DeriveLift DeriveTraversable DerivingStrategies FlexibleContexts FlexibleInstances GADTs GeneralizedNewtypeDeriving LambdaCase MultiParamTypeClasses NoImplicitPrelude NoMonomorphismRestriction OverloadedStrings RankNTypes RecordWildCards ScopedTypeVariables StandaloneDeriving TypeApplications TypeFamilies
+  default-extensions:
+      BangPatterns
+      DataKinds
+      DeriveAnyClass
+      DeriveFoldable
+      DeriveFunctor
+      DeriveGeneric
+      DeriveLift
+      DeriveTraversable
+      DerivingStrategies
+      FlexibleContexts
+      FlexibleInstances
+      GADTs
+      GeneralizedNewtypeDeriving
+      LambdaCase
+      MultiParamTypeClasses
+      NoImplicitPrelude
+      NoMonomorphismRestriction
+      OverloadedStrings
+      RankNTypes
+      RecordWildCards
+      ScopedTypeVariables
+      StandaloneDeriving
+      TypeApplications
+      TypeFamilies
   ghc-options: -threaded -O2 -with-rtsopts=-N
   build-depends:
       async


### PR DESCRIPTION
Per this stackage issue: https://github.com/commercialhaskell/stackage/issues/6032