### PR TITLE
Bump to `lts-18.25` and fix Persistent

### DIFF
--- a/aws-xray-client-persistent/library/Network/AWS/XRayClient/Persistent.hs
+++ b/aws-xray-client-persistent/library/Network/AWS/XRayClient/Persistent.hs
@@ -19,7 +19,7 @@ import Database.Persist.Sql
 import Database.Persist.Sql.Types.Internal
   (IsPersistBackend(mkPersistBackend), SqlBackend(..))
 import Database.Persist.SqlBackend.StatementCache
-  (mkSimpleStatementCache, mkStatementCache, StatementCache)
+  (StatementCache, mkSimpleStatementCache, mkStatementCache)
 import Network.AWS.XRayClient.Segment
 import Network.AWS.XRayClient.TraceId
 import System.Random

--- a/aws-xray-client-persistent/library/Network/AWS/XRayClient/Persistent.hs
+++ b/aws-xray-client-persistent/library/Network/AWS/XRayClient/Persistent.hs
@@ -16,6 +16,8 @@ import Database.Persist
 import Database.Persist.Sql
 import Database.Persist.Sql.Types.Internal
   (IsPersistBackend(mkPersistBackend), SqlBackend(..))
+import Database.Persist.SqlBackend.StatementCache
+  (mkSimpleStatementCache, mkStatementCache)
 import Network.AWS.XRayClient.Segment
 import Network.AWS.XRayClient.TraceId
 import System.Random
@@ -47,7 +49,7 @@ xraySqlBackend sendTrace stdGenIORef subsegmentName =
       , connBegin = binaryTimerWrapper "BEGIN" (connBegin backend)
       , connCommit = unaryTimerWrapper "COMMIT" (connCommit backend)
       , connRollback = unaryTimerWrapper "ROLLBACK" (connRollback backend)
-      , connStmtMap = newConnStmtMap
+      , connStmtMap = mkStatementCache (mkSimpleStatementCache newConnStmtMap)
       }
 
   connPrepare' baseConnPrepare sql = do

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-18.0
+resolver: lts-18.25
 
 packages:
 - aws-xray-client

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -3,10 +3,10 @@
 # For more information, please see the documentation at:
 #   https://docs.haskellstack.org/en/stable/lock_files
 
-packages: []
 snapshots:
-- completed:
-    size: 585393
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/18/0.yaml
-    sha256: c632012da648385b9fa3c29f4e0afd56ead299f1c5528ee789058be410e883c0
-  original: lts-18.0
+- original: lts-18.25
+  completed:
+    sha256: 1b74fb5e970497b5aefae56703f1bd44aa648bd1a5ef95c1eb8c29775087e2bf
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/18/25.yaml
+    size: 587393
+packages: []


### PR DESCRIPTION
Latest LTS updates to `persistent-2.13.3` which [changes the type][0] of `connStmtMap` from `IORef (Map Text Statement)` to `StatementCache`. This change is accommodated through `mkSimpleStatementCache` and `mkStatementCache` [helpers][1].

[0]: https://hackage.haskell.org/package/persistent-2.13.3.0/docs/Database-Persist-Sql-Types-Internal.html#v:connStmtMap
[1]: https://hackage.haskell.org/package/persistent-2.13.3.0/docs/Database-Persist-SqlBackend-StatementCache.html